### PR TITLE
[WINE-68] Auth using user api key

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,13 @@
 source 'https://rubygems.org'
 
-gem 'solidus', github: 'solidusio/solidus', branch: 'master'
+ruby '2.6.6'
+
+gem 'rails', '~> 5.1'
+gem 'rake', '< 11.0'
+gem 'solidus', '2.7.4'
 
 group :test do
+  gem 'factory_bot_rails'
   gem 'flowlink_samples', github: 'pervino/flowlink_samples', branch: 'master'
   gem 'pry-byebug'
 end

--- a/solidus_flowlink.gemspec
+++ b/solidus_flowlink.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'httparty'
 
   gem.add_development_dependency 'capybara', '~> 2.1'
-  gem.add_development_dependency 'coffee-rails', '~> 4.0.0'
-  gem.add_development_dependency 'database_cleaner', '~> 1.3.0' # 1.4.0 is broken https://github.com/DatabaseCleaner/database_cleaner/issues/317
+  gem.add_development_dependency 'coffee-rails', '~> 5.0.0'
+  gem.add_development_dependency 'database_cleaner-active_record', '2.0.0'
   gem.add_development_dependency 'factory_girl', '~> 4.4'
   gem.add_development_dependency 'ffaker'
   gem.add_development_dependency 'mysql2'
   gem.add_development_dependency 'pg'
-  gem.add_development_dependency 'rspec-rails',  '~> 2.13'
-  gem.add_development_dependency 'sass-rails', '~> 4.0.0'
+  gem.add_development_dependency 'rspec-rails', '~> 3.8'
+  gem.add_development_dependency 'sass-rails', '~> 5.0.0'
   gem.add_development_dependency 'selenium-webdriver'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'sqlite3'

--- a/spec/controllers/spree/flowlink/webhook_controller_spec.rb
+++ b/spec/controllers/spree/flowlink/webhook_controller_spec.rb
@@ -1,58 +1,115 @@
 require 'spec_helper'
 
-module Spree
-  describe Flowlink::WebhookController do
+RSpec.describe Spree::Flowlink::WebhookController do
+  include Capybara::RSpecMatchers
 
-    let!(:message) {
-      ::Flowlink::Samples::Order.request
-    }
+  let(:message) { ::Flowlink::Samples::Order.request }
 
-    context '#consume' do
-      context 'with unauthorized request' do
-        it 'returns 401 status' do
-          post 'consume', ::Flowlink::Samples::Order.request.to_json, format: :json, path: 'add_order'
-          expect(response.code).to eql "401"
-          response_json = ::JSON.parse(response.body)
-          expect(response_json["request_id"]).to_not be_nil
-          expect(response_json["summary"]).to eql "Unauthorized!"
-        end
+  describe '#consume' do
+    context 'when authenticating a user' do
+      subject do
+        post(
+          'consume',
+          body: message.to_json,
+          format: :json,
+          params: { path: 'my_custom' }
+        )
       end
 
-      context 'with the correct auth' do
+      context 'with authorization token' do
         before do
-          request.env['HTTP_X_HUB_TOKEN'] = 'abc1233'
+          request.headers['Authorization'] = "Bearer #{user.spree_api_key}"
         end
 
-        context 'and an existing handler for the webhook' do
-          it 'will process the webhook handler' do
-            post 'consume', ::Flowlink::Samples::Order.request.to_json, format: :json, path: 'my_custom'
+        context 'with a user without proper permissions' do
+          let(:user) { create(:user, :with_api_key) }
+          it 'is not authorized' do
+            subject
+            expect(response.code).to eq('401')
+          end
+        end
+
+        context 'with a user with proper permissions' do
+          let(:user) { create(:admin_user, :with_api_key) }
+
+          it 'is authorized' do
+            subject
             expect(response).to be_success
           end
         end
+      end
 
-        context 'when an exception happens' do
-          let(:web_request) do
-            post 'consume', ::Flowlink::Samples::Order.request.to_json, format: :json, path: invalid_path
+      context 'with whitelisted ip address' do
+        context 'with non-whitelisted ip address' do
+          it 'returns 401 status', :aggregrate_failures do
+            subject
+            expect(response.code).to eql "401"
+            response_json = ::JSON.parse(response.body)
+            expect(response_json["request_id"]).to_not be_nil
+            expect(response_json["summary"]).to include "Unauthorized!"
           end
-          let(:invalid_path) { 'upblate_order' }
+        end
 
-          it 'will return resonse with the exception message and backtrace' do
-            web_request
-            expect(response.code).to eql "500"
-            json = JSON.parse(response.body)
-            expect(json["summary"]).to eql "uninitialized constant Spree::Flowlink::Handler::UpblateOrderHandler"
-            expect(json["backtrace"]).to be_present
-          end
-
-          context 'with an error_notifier' do
-            before { Spree::Flowlink::WebhookController.error_notifier = error_notifier }
-            after { Spree::Flowlink::WebhookController.error_notifier = nil }
-            let(:error_notifier) { -> (_responder) {} }
-
-            it 'calls the error_notifier' do
-              expect(error_notifier).to receive(:call)
-              web_request
+        context 'with whitelisted ip address' do
+          context 'with the correct auth' do
+            before do
+              request.remote_ip = '34.75.173.205'
             end
+
+            it 'is authorized' do
+              subject
+              expect(response).to be_success
+            end
+          end
+        end
+      end
+    end
+
+    context 'with the correct auth' do
+      before do
+        request.remote_ip = '34.75.173.205'
+      end
+
+      context 'and an existing handler for the webhook' do
+        it 'will process the webhook handler' do
+          post(
+            'consume',
+            body: message.to_json,
+            format: :json,
+            params: { path: 'my_custom' }
+          )
+          expect(response).to be_success
+        end
+      end
+
+      context 'when an exception happens' do
+        let(:web_request) do
+          post(
+            'consume',
+            body: message.to_json,
+            format: :json,
+            params: { path: invalid_path }
+          )
+        end
+
+        let(:invalid_path) { 'upblate_order' }
+
+        it 'will return response with the exception message and backtrace', :aggregrate_failures do
+          web_request
+          expect(response.code).to eql "500"
+          json = JSON.parse(response.body)
+          expect(json["summary"]).to eql "uninitialized constant Spree::Flowlink::Handler::UpblateOrderHandler"
+          expect(json["backtrace"]).to be_present
+        end
+
+        context 'with an error_notifier' do
+          before { Spree::Flowlink::WebhookController.error_notifier = error_notifier }
+          after { Spree::Flowlink::WebhookController.error_notifier = nil }
+          let(:error_notifier) { -> (_responder) {} }
+
+          it 'calls the error_notifier' do
+            expect(error_notifier).to receive(:call)
+            web_request
           end
         end
       end

--- a/spec/serializers/spree/flowlink/inventory_unit_serializer_spec.rb
+++ b/spec/serializers/spree/flowlink/inventory_unit_serializer_spec.rb
@@ -4,7 +4,7 @@ module Spree
   module Flowlink
     describe InventoryUnitSerializer do
 
-      let(:shipment) { create(:shipment, address: create(:address), order: create(:order_with_line_items)) }
+      let(:shipment) { create(:shipment, order: create(:order_with_line_items)) }
       let(:inventory_unit) { shipment.inventory_units.first }
       let(:serialized_inventory_unit) { JSON.parse (InventoryUnitSerializer.new(inventory_unit, root: false).to_json) }
 

--- a/spec/serializers/spree/flowlink/order_serializer_spec.rb
+++ b/spec/serializers/spree/flowlink/order_serializer_spec.rb
@@ -77,7 +77,6 @@ module Spree
           context 'manual tax from import' do
             before do
               create(:adjustment, adjustable: order, source_type: nil, source_id: nil, amount: 1.14, label: 'Tax', order: order)
-              order.update_totals
             end
 
             it "tax_total matches the manual value" do

--- a/spec/serializers/spree/flowlink/return_item_serializer_spec.rb
+++ b/spec/serializers/spree/flowlink/return_item_serializer_spec.rb
@@ -3,7 +3,10 @@ require "spec_helper"
 module Spree
   module Flowlink
     describe ReturnItemSerializer do
-      let(:return_item) { build(:return_item) }
+      let(:return_item) { build(:return_item, inventory_unit: inventory_unit) }
+      let(:inventory_unit) { create(:inventory_unit, order: order) }
+      let(:order) { create(:order) }
+
       let(:serialized_return_item) { JSON.parse(ReturnItemSerializer.new(return_item, root: false).to_json, symbolize_names: true) }
 
       context "format" do
@@ -34,7 +37,8 @@ module Spree
         end
 
         it "sets the pre_tax_amount" do
-          return_item.pre_tax_amount = 5.0.to_d
+          return_item.amount = 5.0
+          return_item.included_tax_total = 0
           expect(serialized_return_item[:pre_tax_amount]).to eq "5.0"
         end
 

--- a/spec/serializers/spree/flowlink/shipment_serializer_spec.rb
+++ b/spec/serializers/spree/flowlink/shipment_serializer_spec.rb
@@ -4,7 +4,7 @@ module Spree
   module Flowlink
     describe ShipmentSerializer do
 
-      let(:shipment) { create(:shipment, address: create(:address), order: create(:order_with_line_items)) }
+      let(:shipment) { create(:shipment, order: create(:order_with_line_items)) }
       let(:serialized_shipment) { JSON.parse (ShipmentSerializer.new(shipment, root: false).to_json) }
 
       it "serializes the number as id" do
@@ -64,15 +64,15 @@ module Spree
       end
 
       it "serializes the address as billing_address" do
-        expect(serialized_shipment["billing_address"]).to_not be_nil
+        expect(serialized_shipment["bill_to"]).to_not be_nil
         address = JSON.parse(AddressSerializer.new(shipment.order.bill_address, root: false).to_json)
-        expect(serialized_shipment["billing_address"]).to eql address
+        expect(serialized_shipment["bill_to"]).to eql address
       end
 
       it "serializes the address as shipping_address" do
-        expect(serialized_shipment["shipping_address"]).to_not be_nil
+        expect(serialized_shipment["ship_to"]).to_not be_nil
         address = JSON.parse(AddressSerializer.new(shipment.order.ship_address, root: false).to_json)
-        expect(serialized_shipment["shipping_address"]).to eql address
+        expect(serialized_shipment["ship_to"]).to eql address
       end
 
       it "serializes the line_items as items" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ end
 
 require 'rspec/rails'
 require 'rspec/autorun'
-require 'database_cleaner'
+require 'database_cleaner/active_record'
 require 'ffaker'
 require 'flowlink/samples'
 require 'timecop'
@@ -42,7 +42,7 @@ RSpec.configure do |config|
   config.color = true
   config.infer_spec_type_from_file_location!
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   config.include Spree::TestingSupport::Preferences, type: :controller
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
 


### PR DESCRIPTION
Context:
- Currently we an IP address to authorize a connection from flowlink, to update shipments.
- This PR allows us to use the spree api key of an existing user to the the authentication and authorization.
- Note: this Gem was behind in version vs the one used in Personalwine. To make testing easier, I included the current version used in Personalwine.

Next steps required:
- Create a user in production to be used for the flowlink connection and generate an api key for the new user.
- Talk to flowlink so we can setup the use of an api key.
- Allow access via API or IP address, we can look at the logs to ensure that it works via API key. Then we can remove the IP address code.

Note: There needs to be a discussion if its worth further fixing up this Gem, or pulling what is being currently used by Flowlink and port that into the PersonalWine repo.